### PR TITLE
[FEAT] 공통 버튼 컴포넌트 추가 

### DIFF
--- a/developer-test-template/.vscode/settings.json
+++ b/developer-test-template/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "editor.formatOnSave": true,
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
-  },
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
-}

--- a/developer-test-template/src/components/Button.jsx
+++ b/developer-test-template/src/components/Button.jsx
@@ -8,15 +8,15 @@ const Button = ({ label, size, variant, onClick }) => {
   // 디자인 시스템 색상 설정
   const colorClass =
     variant === 'primary'
-      ? 'bg-[#EF6D8A] text-white' // 메인 핑크 (시작하기, 결과 공유하기)
+      ? 'bg-primary text-white' // 메인 핑크 (시작하기, 결과 공유하기)
       : variant === 'secondary'
-        ? 'bg-[#FDF2F3] text-[#EF6D8A]' // 연한 핑크
-        : 'bg-[#F8F0F2] text-[#1E2939]'; // 질문 선택지용
+        ? 'bg-secondary text-primary' // 연한 핑크
+        : 'bg-sub text-gray-700'; // 질문 선택지용
 
   return (
     <button
       onClick={onClick}
-      className={` ${widthClass} ${colorClass} flex h-[56px] cursor-pointer items-center justify-center rounded-full text-[18px] font-bold transition-all active:scale-95`}
+      className={` ${widthClass} ${colorClass} flex h-14 cursor-pointer items-center justify-center rounded-full text-lg font-bold transition-all active:scale-95`}
     >
       {/* 버튼 텍스트 */}
       <span>{label}</span>

--- a/developer-test-template/src/components/Button.jsx
+++ b/developer-test-template/src/components/Button.jsx
@@ -6,17 +6,21 @@ const Button = ({ label, size, variant, onClick }) => {
   const widthClass = size === 'small' ? 'w-[262px]' : 'w-[384px]';
 
   // 디자인 시스템 색상 설정
-  const colorClass =
-    variant === 'primary'
-      ? 'bg-primary text-white' // 메인 핑크 (시작하기, 결과 공유하기)
-      : variant === 'secondary'
-        ? 'bg-background text-primary' // 연한 핑크
-        : 'bg-progress-track text-text-body'; // 질문 선택지용
+  const getVariantClass = () => {
+    switch (variant) {
+      case 'primary':
+        return 'bg-primary text-white shadow-[0_4px_15px_0_rgba(0,0,0,0.12)]'; // 메인 핑크 (시작하기, 결과 공유하기)
+      case 'secondary':
+        return 'bg-background text-primary shadow-sm'; // 연한 핑크
+      default:
+        return 'bg-background text-text-body shadow-sm'; // 질문 선택지용
+    }
+  };
 
   return (
     <button
       onClick={onClick}
-      className={` ${widthClass} ${colorClass} flex h-14 cursor-pointer items-center justify-center rounded-full text-lg font-bold transition-all active:scale-95`}
+      className={` ${widthClass} ${getVariantClass()} flex h-14 cursor-pointer items-center justify-center rounded-full text-lg font-bold transition-all active:scale-95`}
     >
       {/* 버튼 텍스트 */}
       <span>{label}</span>

--- a/developer-test-template/src/components/Button.jsx
+++ b/developer-test-template/src/components/Button.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+// 버튼 컴포넌트
+const Button = ({ label, size, variant, onClick }) => {
+  // 가로 크기 설정
+  const widthClass = size === 'small' ? 'w-[262px]' : 'w-[384px]';
+
+  // 디자인 시스템 색상 설정
+  const colorClass =
+    variant === 'primary'
+      ? 'bg-[#EF6D8A] text-white' // 메인 핑크 (시작하기, 결과 공유하기)
+      : variant === 'secondary'
+        ? 'bg-[#FDF2F3] text-[#EF6D8A]' // 연한 핑크
+        : 'bg-[#F8F0F2] text-[#1E2939]'; // 질문 선택지용
+
+  return (
+    <button
+      onClick={onClick}
+      className={` ${widthClass} ${colorClass} flex h-[56px] cursor-pointer items-center justify-center rounded-full text-[18px] font-bold transition-all active:scale-95`}
+    >
+      {/* 버튼 텍스트 */}
+      <span>{label}</span>
+    </button>
+  );
+};
+
+export default Button;

--- a/developer-test-template/src/components/Button.jsx
+++ b/developer-test-template/src/components/Button.jsx
@@ -9,18 +9,18 @@ const Button = ({ label, size, variant, onClick }) => {
   const getVariantClass = () => {
     switch (variant) {
       case 'primary':
-        return 'bg-primary text-white shadow-[0_4px_15px_0_rgba(0,0,0,0.12)]'; // 메인 핑크 (시작하기, 결과 공유하기)
+        return 'bg-primary text-[#FFFFFF] shadow-[0_10px_15px_0_rgba(0,0,0,0.12)] rounded-full'; // 메인 핑크 (시작하기, 결과 공유하기)
       case 'secondary':
-        return 'bg-background text-primary shadow-sm'; // 연한 핑크
+        return 'bg-background text-[#EF6D8A] rounded-[16px]'; // 연한 핑크
       default:
-        return 'bg-background text-text-body shadow-sm'; // 질문 선택지용
+        return 'bg-background text-[#364153] shadow-[0_1px_3px_0_rgba(0,0,0,0.20)] rounded-[16px]'; // 질문 선택지용
     }
   };
 
   return (
     <button
       onClick={onClick}
-      className={` ${widthClass} ${getVariantClass()} flex h-14 cursor-pointer items-center justify-center rounded-full text-lg font-bold transition-all active:scale-95`}
+      className={` ${widthClass} ${getVariantClass()} flex h-14 cursor-pointer items-center justify-center text-lg font-bold transition-all active:scale-95`}
     >
       {/* 버튼 텍스트 */}
       <span>{label}</span>

--- a/developer-test-template/src/components/Button.jsx
+++ b/developer-test-template/src/components/Button.jsx
@@ -10,8 +10,8 @@ const Button = ({ label, size, variant, onClick }) => {
     variant === 'primary'
       ? 'bg-primary text-white' // 메인 핑크 (시작하기, 결과 공유하기)
       : variant === 'secondary'
-        ? 'bg-secondary text-primary' // 연한 핑크
-        : 'bg-sub text-gray-700'; // 질문 선택지용
+        ? 'bg-background text-primary' // 연한 핑크
+        : 'bg-progress-track text-text-body'; // 질문 선택지용
 
   return (
     <button

--- a/developer-test-template/src/pages/HomePage.jsx
+++ b/developer-test-template/src/pages/HomePage.jsx
@@ -4,8 +4,8 @@ import Button from '../components/Button';
 export default function HomePage() {
   return (
     /* 배경색과 중앙 정렬 레이아웃 */
-    <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-[#FDF2F8]">
-      <div className="text-2xl font-bold text-[#1E2939]">
+    <div className="bg-background flex min-h-screen flex-col items-center justify-center gap-6">
+      <div className="text-text-heading text-2xl font-bold">
         나는 어떤 개발자일까??
       </div>
 

--- a/developer-test-template/src/pages/HomePage.jsx
+++ b/developer-test-template/src/pages/HomePage.jsx
@@ -4,13 +4,27 @@ import Button from '../components/Button';
 export default function HomePage() {
   return (
     /* 배경색과 중앙 정렬 레이아웃 */
-    <div className="bg-background flex min-h-screen flex-col items-center justify-center gap-6">
-      <div className="text-text-heading text-2xl font-bold">
-        나는 어떤 개발자일까??
+    <div className="flex min-h-screen flex-col items-center justify-center gap-10 bg-white p-10">
+      <h1 className="text-text-heading text-2xl font-bold">
+        나는 어떤 개발자일까 ?
+      </h1>
+
+      {/* Primary 버튼 */}
+      <div className="flex flex-col items-center gap-4">
+        <Button label="시작하기" size="small" variant="primary" />
+        <Button label="결과 공유하기" size="medium" variant="primary" />
       </div>
 
-      {/* 버튼 추가 */}
-      <Button label="시작하기" size="small" variant="primary" />
+      {/* Secondary 버튼 */}
+      <div className="flex flex-col items-center">
+        <Button label="다시 테스트하기" size="medium" variant="secondary" />
+      </div>
+
+      {/* Option 버튼 */}
+      <div className="flex flex-col gap-3">
+        <Button label="사용자가 볼 화면부터 디자인한다" size="medium" />
+        <Button label="데이터베이스 구조를 먼저 설계한다" size="medium" />
+      </div>
     </div>
   );
 }

--- a/developer-test-template/src/pages/HomePage.jsx
+++ b/developer-test-template/src/pages/HomePage.jsx
@@ -1,3 +1,16 @@
+import React from 'react';
+import Button from '../components/Button';
+
 export default function HomePage() {
-  return <div className="text-2xl">나는 어떤 개발자일까??</div>;
+  return (
+    /* 배경색과 중앙 정렬 레이아웃 */
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-[#FDF2F8]">
+      <div className="text-2xl font-bold text-[#1E2939]">
+        나는 어떤 개발자일까??
+      </div>
+
+      {/* 버튼 추가 */}
+      <Button label="시작하기" size="small" variant="primary" />
+    </div>
+  );
 }


### PR DESCRIPTION
## 📌 관련 이슈
closed #1

## ✨ 변경 내용
공통 버튼 컴포넌트 구현
시작 페이지(HomePage) 레이아웃

## 📸 스크린샷(선택)
<img width="1544" height="1298" alt="image" src="https://github.com/user-attachments/assets/2050b489-5783-49d5-a7f3-025367a6dca4" />


## 📚 참고사항
공통으로 사용할 수 있게 Button 컴포넌트의 가독성을 높힘
