### PR TITLE
[Refactor] 질문 페이지 리팩토링

### DIFF
--- a/developer-test-template/src/components/Button.jsx
+++ b/developer-test-template/src/components/Button.jsx
@@ -17,7 +17,7 @@ const Button = ({ label, size, variant, onClick }) => {
   return (
     <button
       onClick={onClick}
-      className={`${widthClass} ${getVariantClass()} flex h-12 shrink-0 cursor-pointer items-center justify-center text-lg font-bold transition-all active:scale-95`}
+      className={`${widthClass} ${getVariantClass()} flex shrink-0 cursor-pointer px-6 py-4 text-base font-medium transition-all active:scale-95`}
     >
       <span>{label}</span>
     </button>

--- a/developer-test-template/src/components/Card.jsx
+++ b/developer-test-template/src/components/Card.jsx
@@ -1,7 +1,7 @@
 function Card({ className, children, ...props }) {
   return (
     <div
-      className={`size-fit rounded-3xl bg-white p-8 shadow-[0_25px_50px_-12px_rgba(0,0,0,0.25)]`}
+      className={`size-fit rounded-3xl bg-white p-8 shadow-[0_25px_50px_-12px_rgba(0,0,0,0.25)] ${className}`}
       {...props}
     >
       {children}

--- a/developer-test-template/src/mocks/data/question.js
+++ b/developer-test-template/src/mocks/data/question.js
@@ -1,0 +1,74 @@
+const questionList = [
+  {
+    id: 1,
+    text: '새로운 프로젝트를 시작할 때 가장 먼저 하는 일은?',
+    options: [
+      {
+        text: '사용자가 볼 화면부터 디자인한다',
+        type: 'frontend',
+      },
+      {
+        text: '데이터베이스 구조를 먼저 설계한다',
+        type: 'backend',
+      },
+    ],
+  },
+  {
+    id: 2,
+    text: '어떤 문제 해결에 흥미를 느끼나요?',
+    options: [
+      {
+        text: '화면이 예쁘게 보이도록 만드는 것',
+        type: 'frontend',
+      },
+      {
+        text: '복잡한 로직과 알고리즘 구현',
+        type: 'backend',
+      },
+    ],
+  },
+  {
+    id: 3,
+    text: '가장 관심 있는 기술 분야는?',
+    options: [
+      {
+        text: '데이터 분석과 머신러닝',
+        type: 'data',
+      },
+      {
+        text: '모바일 앱 개발',
+        type: 'mobile',
+      },
+    ],
+  },
+  {
+    id: 4,
+    text: '협업할 때 나의 역할은?',
+    options: [
+      {
+        text: '프론트엔드와 백엔드 모두 다룬다',
+        type: 'fullstack',
+      },
+      {
+        text: '서버 배포와 인프라 관리',
+        type: 'devops',
+      },
+    ],
+  },
+  {
+    id: 5,
+    text: '가장 만들고 싶은 프로젝트는?',
+    options: [
+      {
+        text: '게임이나 인터랙티브 콘텐츠',
+        type: 'gamedev',
+      },
+      {
+        text: 'AI 챗봇이나 추천 시스템',
+        type: 'ai',
+      },
+    ],
+  },
+];
+
+export default questionList;

--- a/developer-test-template/src/pages/HomePage.jsx
+++ b/developer-test-template/src/pages/HomePage.jsx
@@ -9,15 +9,15 @@ export default function HomePage() {
     /* 배경 */
     <div className="bg-background flex min-h-screen items-center justify-center p-4">
       {/* 메인 카드 컨테이너 */}
-      <div className="relative flex h-[524px] w-[326.02px] flex-col items-center justify-between overflow-hidden rounded-3xl bg-white p-[32px] shadow-2xl">
+      <div className="relative flex h-131 w-[326.02px] flex-col items-center justify-between overflow-hidden rounded-3xl bg-white p-8 shadow-2xl">
         {/* 상단 구역 */}
         <div className="flex w-full flex-col items-center">
           {/* 캐릭터 이미지 */}
-          <div className="flex h-[180px] items-center justify-center">
+          <div className="flex h-45 items-center justify-center">
             <img
               src="/src/assets/Icon.webp"
               alt="Hamster"
-              className="h-[128px] w-[128px] object-contain"
+              className="h-32 w-32 object-contain"
             />
           </div>
 
@@ -34,7 +34,7 @@ export default function HomePage() {
           </div>
 
           {/* 안내 박스 */}
-          <div className="bg-background mt-8 flex h-[72px] w-full items-center justify-center rounded-[14px]">
+          <div className="bg-background mt-8 flex h-18 w-full items-center justify-center rounded-[14px]">
             {/* 안내 문구 */}
             <p className="text-primary text-center text-sm leading-tight font-semibold">
               ✨ 5개의 질문으로 알아보는

--- a/developer-test-template/src/pages/QuestionPage.jsx
+++ b/developer-test-template/src/pages/QuestionPage.jsx
@@ -4,6 +4,7 @@ import Card from '../components/Card';
 import ProgressBar from '../components/ProgressBar';
 import Button from '../components/Button';
 import questionList from '../mocks/data/question';
+import CharacterIcon from '../components/CharacterIcon';
 
 export default function QuestionPage() {
   const [currentStep, setCurrentStep] = useState(1);
@@ -19,25 +20,19 @@ export default function QuestionPage() {
   };
 
   return (
-    <div className="bg-background flex min-h-screen items-center justify-center p-4">
-      <Card className="flex h-150 w-md flex-col justify-between p-10">
+    <div className="bg-background flex min-h-screen items-center justify-center">
+      <Card className="flex flex-col items-center gap-8">
         <ProgressBar value={currentStep} max={5} />
 
-        <div className="flex flex-1 flex-col items-center justify-center gap-10">
-          <img
-            src="/src/assets/Icon.webp"
-            alt="Hamster"
-            className="h-32.5 w-32.5 object-contain"
-          />
+        <CharacterIcon type="hamster" />
 
-          <div className="space-y-3 text-center">
-            <span className="text-primary block text-2xl font-bold">
-              Q{currentStep}.
-            </span>
-            <h2 className="text-text-heading text-2xl leading-relaxed font-bold whitespace-pre-wrap">
-              {currentData.text}
-            </h2>
-          </div>
+        <div className="flex flex-1 flex-col items-center justify-center gap-2">
+          <span className="text-text-heading text-2xl font-medium">
+            Q{currentStep}.
+          </span>
+          <h2 className="text-text-description text-base leading-relaxed font-normal whitespace-pre-wrap">
+            {currentData.text}
+          </h2>
         </div>
 
         <div className="mb-4 flex w-full flex-col gap-4">
@@ -46,7 +41,7 @@ export default function QuestionPage() {
               key={index}
               label={option.text}
               variant="default"
-              className="py-5 text-base"
+              className="text-base"
               onClick={handleNext}
             />
           ))}

--- a/developer-test-template/src/pages/QuestionPage.jsx
+++ b/developer-test-template/src/pages/QuestionPage.jsx
@@ -20,14 +20,14 @@ export default function QuestionPage() {
 
   return (
     <div className="bg-background flex min-h-screen items-center justify-center p-4">
-      <Card className="flex h-[600px] w-[448px] flex-col justify-between p-10">
+      <Card className="flex h-150 w-md flex-col justify-between p-10">
         <ProgressBar value={currentStep} max={5} />
 
         <div className="flex flex-1 flex-col items-center justify-center gap-10">
           <img
             src="/src/assets/Icon.webp"
             alt="Hamster"
-            className="h-[130px] w-[130px] object-contain"
+            className="h-32.5 w-32.5 object-contain"
           />
 
           <div className="space-y-3 text-center">

--- a/developer-test-template/src/pages/QuestionPage.jsx
+++ b/developer-test-template/src/pages/QuestionPage.jsx
@@ -3,46 +3,7 @@ import { useNavigate } from 'react-router';
 import Card from '../components/Card';
 import ProgressBar from '../components/ProgressBar';
 import Button from '../components/Button';
-
-const questionList = [
-  {
-    id: 1,
-    text: '새로운 프로젝트를 시작할 때\n가장 먼저 하는 일은?',
-    options: [
-      '사용자가 볼 화면부터 디자인한다',
-      '데이터베이스 구조를 먼저 설계한다',
-    ],
-  },
-  {
-    id: 2,
-    text: '코드 에러가 발생했을 때\n나의 대처 방식은?',
-    options: ['구글링과 AI의 도움을 받는다', '공식 문서와 로그를 끝까지 판다'],
-  },
-  {
-    id: 3,
-    text: '협업 도중 의견 충돌이 생기면?',
-    options: [
-      '논리적인 근거로 팀원을 설득한다',
-      '팀 전체의 분위기를 먼저 살핀다',
-    ],
-  },
-  {
-    id: 4,
-    text: '작성한 코드가 잘 돌아간다면?',
-    options: [
-      '더 효율적인 코드로 리팩토링한다',
-      '다음 기능을 구현하러 바로 떠난다',
-    ],
-  },
-  {
-    id: 5,
-    text: '마감 기한이 코앞으로 다가왔다면?',
-    options: [
-      '밤을 새워서라도 완벽하게 끝낸다',
-      '기능 우선순위를 정해 핵심만 구현한다',
-    ],
-  },
-];
+import questionList from '../mocks/data/question';
 
 export default function QuestionPage() {
   const [currentStep, setCurrentStep] = useState(1);
@@ -83,7 +44,7 @@ export default function QuestionPage() {
           {currentData.options.map((option, index) => (
             <Button
               key={index}
-              label={option}
+              label={option.text}
               variant="default"
               className="py-5 text-base"
               onClick={handleNext}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #23

## ✨ 변경 내용
<!-- 변경한 내용을 간략하게 설명해주세요. -->
- 질문 페이지의 UI를 피그마 디자인과 일치하도록 일부 스타일링을 수정했습니다.
- 질문 더미 데이터의 형식을 스웨거를 참고해 일부 수정했습니다.
- 질문 더미 데이터를 **src/mocks/data** 폴더에 **questions.js**를 생성하여 분리했습니다.

## 📸 스크린샷(선택)
<!-- 스크린샷이 있다면 첨부해주세요. -->
<img width="1434" height="678" alt="image" src="https://github.com/user-attachments/assets/8a34cc37-a120-4955-8ab6-16f1a773563c" />


## 📚 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
현재 페이지마다 동일한 레이아웃을 갖고 있습니다!! 결과 페이지랑 라우터 부분 모두 병합되면 아래 사항 추가로 작업하면 좋을 것 같습니다!!
- [ ] 레이아웃 분리 및 적용
- [ ] 카드 내 푸터 분리 및 적용