### PR TITLE
[FEAT] 결과페이지 UI 구현

### DIFF
--- a/developer-test-template/src/App.jsx
+++ b/developer-test-template/src/App.jsx
@@ -2,6 +2,7 @@ import './App.css';
 import { Routes, Route } from 'react-router';
 import HomePage from './pages/HomePage';
 import QuestionPage from './pages/QuestionPage';
+import ResultPage from './pages/ResultPage';
 
 function App() {
   return (

--- a/developer-test-template/src/App.jsx
+++ b/developer-test-template/src/App.jsx
@@ -13,7 +13,7 @@ function App() {
       <Route path="/question" element={<QuestionPage />} />
 
       {/* 결과페이지로 연결되는곳 */}
-      <Route path="/result" element={null} />
+      <Route path="/result" element={<ResultPage />} />
     </Routes>
   );
 }

--- a/developer-test-template/src/components/Badge.jsx
+++ b/developer-test-template/src/components/Badge.jsx
@@ -1,12 +1,12 @@
 function Badge({ tags }) {
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex flex-wrap justify-center gap-2">
       {tags.map((tag) => (
         <div
           key={tag}
-          className="bg-background flex items-center rounded-full px-3 py-[6px]"
+          className="bg-background flex h-[28px] items-center rounded-full px-2"
         >
-          <span className="font-inter text-primary text-sm leading-5 font-medium tracking-[-0.15px]">
+          <span className="text-primary text-[14px] leading-[20px] font-normal tracking-[-0.15px]">
             #{tag}
           </span>
         </div>

--- a/developer-test-template/src/pages/ResultPage.jsx
+++ b/developer-test-template/src/pages/ResultPage.jsx
@@ -64,46 +64,51 @@ export default function ResultPage() {
         </section>
 
         {/* 해시태그 */}
-        <div className="mx-auto flex w-full max-w-[384px] justify-center">
-          <Badge tags={result.hashtags} />
+        <div className="mx-auto w-full max-w-[384px]">
+          <div className="flex flex-wrap justify-center gap-2">
+            <Badge tags={result.hashtags} />
+          </div>
         </div>
 
         {/* 특징 */}
         <section className="bg-background space-y-3 rounded-2xl px-5 py-6 text-left">
-          <h3 className="text-text-heading text-center font-semibold">
+          <h3 className="text-text-heading text-center text-[16px] leading-[24px] font-medium tracking-[-0.31px]">
             나의 특징
           </h3>
+
           <ul className="space-y-2">
             {result.features.map((feature, idx) => (
-              <li key={idx} className="text-text-body flex gap-2">
+              <li key={idx} className="flex gap-2">
                 <span className="text-primary">•</span>
-                <span>{feature}</span>
+                <span className="text-text-body text-[14px] leading-[22px] font-normal">
+                  {feature}
+                </span>
               </li>
             ))}
           </ul>
         </section>
 
         {/* 버튼 */}
-        <div className="flex flex-col items-center gap-4">
-          <div className="flex items-center gap-2">
+        <div className="flex flex-col gap-4">
+          <Button
+            size="large"
+            variant="primary"
+            onClick={handleShare}
+            className="flex w-full items-center justify-center gap-2"
+          >
             <Icon name="share" />
-            <Button
-              label="결과 공유하기"
-              size="large"
-              variant="primary"
-              onClick={handleShare}
-            />
-          </div>
+            결과 공유하기
+          </Button>
 
-          <div className="flex items-center gap-2">
+          <Button
+            size="large"
+            variant="secondary"
+            onClick={handleRestart}
+            className="flex w-full items-center justify-center gap-2"
+          >
             <Icon name="refresh" />
-            <Button
-              label="다시 테스트하기"
-              size="large"
-              variant="secondary"
-              onClick={handleRestart}
-            />
-          </div>
+            다시 테스트하기
+          </Button>
         </div>
       </Card>
     </main>

--- a/developer-test-template/src/pages/ResultPage.jsx
+++ b/developer-test-template/src/pages/ResultPage.jsx
@@ -2,7 +2,7 @@ import Card from '../components/Card';
 import Badge from '../components/Badge';
 import Button from '../components/Button';
 import Icon from '../components/Icon';
-import ProgressBar from '../components/ProgressBar';
+import frontendCharacter from '../assets/characters/frontend.webp';
 
 const dummyResult = {
   type: '프론트엔드 벌',
@@ -34,39 +34,48 @@ export default function ResultPage() {
   return (
     <main className="flex min-h-screen justify-center bg-gray-50 py-10">
       <Card className="w-[420px] space-y-8 text-center">
-        {/* 진행률 */}
-        <ProgressBar value={10} max={10} />
-
         {/* 타이틀 */}
         <section className="space-y-1">
-          <p className="text-text-muted text-sm">당신의 개발자 유형</p>
-          <h1 className="text-primary text-2xl font-bold">{result.type}</h1>
+          <p className="text-text-description text-center text-[20px] leading-[30px] font-medium tracking-[-0.45px]">
+            당신의 개발자 유형
+          </p>
+          <h1 className="text-primary text-center text-[24px] leading-[32px] font-medium tracking-[0.07px]">
+            {result.type}
+          </h1>
         </section>
 
         {/* 캐릭터 */}
         <div className="flex justify-center">
           <img
-            src="/images/bee.png"
-            alt="result character"
-            className="h-40 w-40"
+            src={frontendCharacter}
+            alt="프론트엔드 벌 캐릭터"
+            className="h-[180px] w-[180px]"
           />
         </div>
 
         {/* 설명 */}
         <section className="space-y-2">
-          <h2 className="text-lg font-semibold">{result.title}</h2>
-          <p className="text-text-body leading-relaxed">{result.description}</p>
+          <h2 className="text-text-heading text-center text-[18px] leading-[28px] font-medium tracking-[-0.44px]">
+            {result.title}
+          </h2>
+          <p className="text-text-description text-center text-[14px] leading-[22.75px] font-normal tracking-[-0.15px]">
+            {result.description}
+          </p>
         </section>
 
         {/* 해시태그 */}
-        <Badge tags={result.hashtags} />
+        <div className="mx-auto flex w-full max-w-[384px] justify-center">
+          <Badge tags={result.hashtags} />
+        </div>
 
         {/* 특징 */}
         <section className="bg-background space-y-3 rounded-2xl px-5 py-6 text-left">
-          <h3 className="text-center font-semibold">나의 특징</h3>
+          <h3 className="text-text-heading text-center font-semibold">
+            나의 특징
+          </h3>
           <ul className="space-y-2">
             {result.features.map((feature, idx) => (
-              <li key={idx} className="flex gap-2">
+              <li key={idx} className="text-text-body flex gap-2">
                 <span className="text-primary">•</span>
                 <span>{feature}</span>
               </li>

--- a/developer-test-template/src/pages/ResultPage.jsx
+++ b/developer-test-template/src/pages/ResultPage.jsx
@@ -33,13 +33,13 @@ export default function ResultPage() {
 
   return (
     <main className="flex min-h-screen justify-center bg-gray-50 py-10">
-      <Card className="w-[420px] space-y-8 text-center">
+      <Card className="w-105 space-y-8 text-center">
         {/* 타이틀 */}
         <section className="space-y-1">
-          <p className="text-text-description text-center text-[20px] leading-[30px] font-medium tracking-[-0.45px]">
+          <p className="text-text-description text-center text-xl leading-7 font-medium tracking-[-0.45px]">
             당신의 개발자 유형
           </p>
-          <h1 className="text-primary text-center text-[24px] leading-[32px] font-medium tracking-[0.07px]">
+          <h1 className="text-primary text-center text-2xl leading-8 font-medium tracking-[0.07px]">
             {result.type}
           </h1>
         </section>
@@ -49,22 +49,22 @@ export default function ResultPage() {
           <img
             src={frontendCharacter}
             alt="프론트엔드 벌 캐릭터"
-            className="h-[180px] w-[180px]"
+            className="h-45 w-45"
           />
         </div>
 
         {/* 설명 */}
         <section className="space-y-2">
-          <h2 className="text-text-heading text-center text-[18px] leading-[28px] font-medium tracking-[-0.44px]">
+          <h2 className="text-text-heading text-center text-lg leading-7 font-medium tracking-[-0.44px]">
             {result.title}
           </h2>
-          <p className="text-text-description text-center text-[14px] leading-[22.75px] font-normal tracking-[-0.15px]">
+          <p className="text-text-description text-center text-sm leading-[22.75px] font-normal tracking-[-0.15px]">
             {result.description}
           </p>
         </section>
 
         {/* 해시태그 */}
-        <div className="mx-auto w-full max-w-[384px]">
+        <div className="mx-auto w-full max-w-96">
           <div className="flex flex-wrap justify-center gap-2">
             <Badge tags={result.hashtags} />
           </div>
@@ -72,7 +72,7 @@ export default function ResultPage() {
 
         {/* 특징 */}
         <section className="bg-background space-y-3 rounded-2xl px-5 py-6 text-left">
-          <h3 className="text-text-heading text-center text-[16px] leading-[24px] font-medium tracking-[-0.31px]">
+          <h3 className="text-text-heading text-center text-base leading-6 font-medium tracking-[-0.31px]">
             나의 특징
           </h3>
 
@@ -80,7 +80,7 @@ export default function ResultPage() {
             {result.features.map((feature, idx) => (
               <li key={idx} className="flex gap-2">
                 <span className="text-primary">•</span>
-                <span className="text-text-body text-[14px] leading-[22px] font-normal">
+                <span className="text-text-body text-sm leading-6 font-normal">
                   {feature}
                 </span>
               </li>

--- a/developer-test-template/src/pages/ResultPage.jsx
+++ b/developer-test-template/src/pages/ResultPage.jsx
@@ -1,0 +1,102 @@
+import Card from '../components/Card';
+import Badge from '../components/Badge';
+import Button from '../components/Button';
+import Icon from '../components/Icon';
+import ProgressBar from '../components/ProgressBar';
+
+const dummyResult = {
+  type: '프론트엔드 벌',
+  title: '예쁜 걸 사랑하는 디자이너 벌',
+  description:
+    '사용자가 보는 화면을 아름답게 만드는 것이 가장 큰 즐거움! 색상, 레이아웃, 애니메이션에 진심인 당신은 프론트엔드 전문가입니다.',
+  hashtags: ['React', 'CSS', '디자인', 'UI', '사용자경험'],
+  features: [
+    '디테일에 강한 관찰력을 가지고 있다',
+    'UI/UX에 대한 감각이 뛰어나다',
+    '사용자 경험을 최우선으로 생각한다',
+    '새로운 디자인 트렌드에 관심이 많다',
+    '시각적인 완성도를 중요하게 생각한다',
+  ],
+};
+
+export default function ResultPage() {
+  const result = dummyResult;
+
+  const handleShare = () => {
+    navigator.clipboard.writeText(window.location.href);
+    alert('링크가 복사되었습니다!');
+  };
+
+  const handleRestart = () => {
+    // 나중에 상태 초기화 연결
+  };
+
+  return (
+    <main className="flex min-h-screen justify-center bg-gray-50 py-10">
+      <Card className="w-[420px] space-y-8 text-center">
+        {/* 진행률 */}
+        <ProgressBar value={10} max={10} />
+
+        {/* 타이틀 */}
+        <section className="space-y-1">
+          <p className="text-text-muted text-sm">당신의 개발자 유형</p>
+          <h1 className="text-primary text-2xl font-bold">{result.type}</h1>
+        </section>
+
+        {/* 캐릭터 */}
+        <div className="flex justify-center">
+          <img
+            src="/images/bee.png"
+            alt="result character"
+            className="h-40 w-40"
+          />
+        </div>
+
+        {/* 설명 */}
+        <section className="space-y-2">
+          <h2 className="text-lg font-semibold">{result.title}</h2>
+          <p className="text-text-body leading-relaxed">{result.description}</p>
+        </section>
+
+        {/* 해시태그 */}
+        <Badge tags={result.hashtags} />
+
+        {/* 특징 */}
+        <section className="bg-background space-y-3 rounded-2xl px-5 py-6 text-left">
+          <h3 className="text-center font-semibold">나의 특징</h3>
+          <ul className="space-y-2">
+            {result.features.map((feature, idx) => (
+              <li key={idx} className="flex gap-2">
+                <span className="text-primary">•</span>
+                <span>{feature}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* 버튼 */}
+        <div className="flex flex-col items-center gap-4">
+          <div className="flex items-center gap-2">
+            <Icon name="share" />
+            <Button
+              label="결과 공유하기"
+              size="large"
+              variant="primary"
+              onClick={handleShare}
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Icon name="refresh" />
+            <Button
+              label="다시 테스트하기"
+              size="large"
+              variant="secondary"
+              onClick={handleRestart}
+            />
+          </div>
+        </div>
+      </Card>
+    </main>
+  );
+}


### PR DESCRIPTION
## 📌 관련 이슈
closed #25

## ✨ 변경 내용

- ResultPage UI 구현
- Figma 디자인 기준 타이포그래피 적용
- 컬러 토큰 적용
- 해시태그(Badge) 스타일 수정
- 나의 특징 카드 스타일 적용
- 버튼 UI 정리
- 
## 📸 스크린샷(선택)
<img width="394" height="859" alt="스크린샷 2026-03-04 오후 2 58 17" src="https://github.com/user-attachments/assets/b017adf1-b1a4-4720-bdee-5a7bcbc4d4e4" />

## 📚 참고사항
api 연동 해야합니다.